### PR TITLE
Updated docs to use ContentComponent instead of FormComponent.

### DIFF
--- a/docs/workflow/sdk-mobile-form-reference.mdx
+++ b/docs/workflow/sdk-mobile-form-reference.mdx
@@ -4,7 +4,7 @@ sidebar_label: Form Element Reference
 description: VertiGIS Studio Workflow - Reference for workflow form elements for web applications
 ---
 
-In the VertiGIS Studio Workflow .NET SDK, all custom form elements must implement `IFormComponent`. However, it is typically easier to extend the `ContentComponent` class, which is the recommend practice. The examples shown here extend `ContentComponent`.
+In the VertiGIS Studio Workflow .NET SDK, all custom form elements must implement `IFormComponent`. However, it is typically easier to extend the `ContentComponent` class, which is the recommended practice. The examples shown here extend `ContentComponent`.
 
 ```xml title="App1/App1/workflow/CustomFormElement.xaml"
 <?xml version="1.0" encoding="UTF-8"?>
@@ -55,7 +55,7 @@ namespace App1.Workflow
 
 ## Using Form Elements
 
-Custom form elements can be used in a form through the special ["custom" form element](https://docs.geocortex.com/workflow/latest/help/Default.htm#wf5/help/form-elements/custom.htm#Custom_Form_Elements%3FTocPath%3DForms%7CForm%2520Element%2520Reference%7CCustom%2520Form%2520Elements%7C_____0). This form element displays custom form elements by referencing them by the `id` they were registered with.
+Custom form elements can be used in a form through the special ["custom" form element](https://docs.vertigisstudio.com/workflow/latest/help/Default.htm#wf5/help/form-elements/custom.htm#Custom_Form_Elements%3FTocPath%3DForms%7CForm%2520Element%2520Reference%7CCustom%2520Form%2520Elements%7C_____0). This form element displays custom form elements by referencing them by the `id` they were registered with.
 
 :::important
 Custom form elements will **only** be available to a workflow if the form element registration activity is run beforehand. It's best practice to run the form element registration activity at the start of a workflow.
@@ -63,7 +63,7 @@ Custom form elements will **only** be available to a workflow if the form elemen
 
 ## Raising Form Events
 
-VertiGIS Studio Workflow form elements can raise [events](https://docs.geocortex.com/workflow/latest/help/Default.htm#wf5/help/forms.htm#Events%3FTocPath%3DForms%7COverview%2520of%2520Forms%7CEvents%7C_____0). A custom form element can also raise events, including a custom event type.
+VertiGIS Studio Workflow form elements can raise [events](https://docs.vertigisstudio.com/workflow/latest/help/Default.htm#wf5/help/forms.htm#Events%3FTocPath%3DForms%7COverview%2520of%2520Forms%7CEvents%7C_____0). A custom form element can also raise events, including a custom event type.
 
 Events are raised through the `OnEventRaised` method of the form component. The following custom form elements demonstrates how various form events can be raised.
 
@@ -163,4 +163,4 @@ namespace App1.Workflow
 }
 ```
 
-You can then use the [Get Form Element Property](https://docs.geocortex.com/workflow/latest/help/Default.htm#wf5/help/activities/get-form-element-property.htm) activity to access the `Value` property, along with [other properties supported by custom form elements](https://docs.geocortex.com/workflow/latest/help/Default.htm#wf5/help/form-elements/custom.htm#Custom_Form_Element_Properties%3FTocPath%3DForms%7CForm%2520Element%2520Reference%7CCustom%2520Form%2520Elements%7C_____1).
+You can then use the [Get Form Element Property](https://docs.vertigisstudio.com/workflow/latest/help/Default.htm#wf5/help/activities/get-form-element-property.htm) activity to access the `Value` property, along with [other properties supported by custom form elements](https://docs.vertigisstudio.com/workflow/latest/help/Default.htm#wf5/help/form-elements/custom.htm#Custom_Form_Element_Properties%3FTocPath%3DForms%7CForm%2520Element%2520Reference%7CCustom%2520Form%2520Elements%7C_____1).

--- a/docs/workflow/sdk-mobile-form-reference.mdx
+++ b/docs/workflow/sdk-mobile-form-reference.mdx
@@ -65,7 +65,7 @@ Custom form elements will **only** be available to a workflow if the form elemen
 
 VertiGIS Studio Workflow form elements can raise [events](https://docs.vertigisstudio.com/workflow/latest/help/Default.htm#wf5/help/forms.htm#Events%3FTocPath%3DForms%7COverview%2520of%2520Forms%7CEvents%7C_____0). A custom form element can also raise events, including a custom event type.
 
-Events are raised through the `OnEventRaised` method of the form component. The following custom form elements demonstrates how various form events can be raised.
+Events are raised through the `OnEventRaised` method of the form component. The following custom form element demonstrates how various form events can be raised.
 
 ```xml title="App1/App1/workflow/CustomFormComponent.xaml"
 <?xml version="1.0" encoding="UTF-8"?>

--- a/docs/workflow/sdk-mobile-form-reference.mdx
+++ b/docs/workflow/sdk-mobile-form-reference.mdx
@@ -4,21 +4,29 @@ sidebar_label: Form Element Reference
 description: VertiGIS Studio Workflow - Reference for workflow form elements for web applications
 ---
 
-In the VertiGIS Studio Workflow .NET SDK, form elements are represented by classes that extend the `FormComponent` class.
+In the VertiGIS Studio Workflow .NET SDK, the only requirement is that custom form elements must implement `IFormComponent`. However, it is typically easier to extend the `ContentComponent` class, which is the recommend practice. The examples shown here extend `ContentComponent`.
 
-```cs
+```xml title="App1/App1/workflow/CustomFormElement.xaml"
+<?xml version="1.0" encoding="UTF-8"?>
+<core:ContentComponent xmlns="http://xamarin.com/schemas/2014/forms"
+                       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                       xmlns:core="clr-namespace:VertiGIS.Mobile.Workflow.Core;assembly=VertiGIS.Mobile.Workflow"
+                       xmlns:views="clr-namespace:VertiGIS.Mobile.Toolkit.Views;assembly=VertiGIS.Mobile.Toolkit"
+                       x:Class="App1.Workflow.CustomFormElement">
+    <Label Text="I'm a custom form element"/>
+</core:ContentComponent>
+```
+
+```cs title="App1/App1/workflow/CustomFormElement.xaml.cs"
 namespace App1.Workflow
 {
-    class CustomFormElement : FormComponent
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class CustomFormElement : ContentComponent
     {
         public CustomFormElement(Geocortex.Workflow.Runtime.Definition.Forms.Element element, string name)
-            : base (element, name)
+            : base(element, name)
         {
-            _view = new Label(){
-                Text = "I'm a custom form element"
-            }
-
-            Add(new GenericComponent(_view));
+            InitializeComponent();
         }
     }
 }
@@ -28,7 +36,7 @@ namespace App1.Workflow
 
 Form Elements must be registered through a [custom workflow activity that extends `RegisterCustomFormElementBase`](sdk-mobile-activity-reference.mdx#registering-activities).
 
-```cs
+```cs title="App1/App1/workflow/RegisterComponent.cs"
 [assembly: Export(typeof(RegisterCustomFormElements))]
 namespace App1.Workflow
 {
@@ -47,7 +55,7 @@ namespace App1.Workflow
 
 ## Using Form Elements
 
-Custom form elements can be used in a form through the special ["custom" form element](https://docs.vertigisstudio.com/workflow/latest/help/Default.htm#wf5/help/form-elements/custom.htm#Custom_Form_Elements%3FTocPath%3DForms%7CForm%2520Element%2520Reference%7CCustom%2520Form%2520Elements%7C_____0). This form element displays custom form elements by referencing them by the `id` they were registered with.
+Custom form elements can be used in a form through the special ["custom" form element](https://docs.geocortex.com/workflow/latest/help/Default.htm#wf5/help/form-elements/custom.htm#Custom_Form_Elements%3FTocPath%3DForms%7CForm%2520Element%2520Reference%7CCustom%2520Form%2520Elements%7C_____0). This form element displays custom form elements by referencing them by the `id` they were registered with.
 
 :::important
 Custom form elements will **only** be available to a workflow if the form element registration activity is run beforehand. It's best practice to run the form element registration activity at the start of a workflow.
@@ -55,59 +63,56 @@ Custom form elements will **only** be available to a workflow if the form elemen
 
 ## Raising Form Events
 
-VertiGIS Studio Workflow form elements can raise [events](https://docs.vertigisstudio.com/workflow/latest/help/Default.htm#wf5/help/forms.htm#Events%3FTocPath%3DForms%7COverview%2520of%2520Forms%7CEvents%7C_____0). A custom form element can also raise events, including a custom event type.
+VertiGIS Studio Workflow form elements can raise [events](https://docs.geocortex.com/workflow/latest/help/Default.htm#wf5/help/forms.htm#Events%3FTocPath%3DForms%7COverview%2520of%2520Forms%7CEvents%7C_____0). A custom form element can also raise events, including a custom event type.
 
 Events are raised through the `OnEventRaised` method of the form component. The following custom form elements demonstrates how various form events can be raised.
 
-```cs
+```xml title="App1/App1/workflow/CustomFormComponent.xaml"
+<?xml version="1.0" encoding="UTF-8"?>
+<core:ContentComponent  xmlns:core="clr-namespace:VertiGIS.Mobile.Workflow.Core;assembly=VertiGIS.Mobile.Workflow"
+                        xmlns="http://xamarin.com/schemas/2014/forms"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                        xmlns:views="clr-namespace:VertiGIS.Mobile.Toolkit.Views;assembly=VertiGIS.Mobile.Toolkit"
+                        x:Class="App1.Workflow.CustomFormComponent">
+    <StackLayout>
+        <views:EnhancedButton Text="Raise Clicked Event" Clicked="RaiseClickedEvent"/>
+        <views:EnhancedButton Text="Raise Changed Event" Clicked="RaiseChangedEvent"/>
+        <views:EnhancedButton Text="Raise Custom Event" Clicked="RaiseCustomEvent"/>
+    </StackLayout>
+</core:ContentComponent>
+```
+
+```cs title="App1/App1/workflow/CustomFormComponent.xaml.cs"
 namespace App1.Workflow
 {
-    class CustomFormComponent : FormComponent
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class CustomFormComponent : ContentComponent
     {
-        private readonly StackLayout _view;
-
         public CustomFormComponent(Geocortex.Workflow.Runtime.Definition.Forms.Element element, string name)
-            : base (element, name)
+            : base(element, name)
         {
-            _view = new StackLayout();
-
-            _view.Children.Add(new EnhancedButton() {
-                Command = new Command(RaiseClickedEvent),
-                Text = "Raise Clicked Event"
-            });
-
-            _view.Children.Add(new EnhancedButton() {
-                Command = new Command(RaiseChangedEvent),
-                Text = "Raise Changed Event"
-            });
-
-            _view.Children.Add(new EnhancedButton() {
-                Command = new Command(RaiseCustomEvent),
-                Text = "Raise Custom Event"
-            });
-
-            Add(new GenericComponent(_view));
+            InitializeComponent();
         }
 
-        private void RaiseClickedEvent()
+        private void RaiseClickedEvent(object sender, EventArgs e)
         {
-            OnEventRaised(new Event()
+            RaiseEvent(new Event()
             {
                 Type = Event.CLICKED
             });
         }
 
-        private void RaiseChangedEvent()
+        private void RaiseChangedEvent(object sender, EventArgs e)
         {
-            OnEventRaised(new Event()
+            RaiseEvent(new Event()
             {
                 Type = Event.CHANGED
             });
         }
 
-        private void RaiseCustomEvent()
+        private void RaiseCustomEvent(object sender, EventArgs e)
         {
-            OnEventRaised(new Event()
+            RaiseEvent(new Event()
             {
                 Type = Event.CUSTOM,
                 Argument = "Custom Argument"
@@ -121,27 +126,41 @@ namespace App1.Workflow
 
 A custom form element may produce a value that a workflow needs to access at runtime. You can set a property on the `this.element` object to expose that value to the form.
 
-```cs
+```xml title="App1/App1/workflow/CustomFormComponent.xaml"
+<?xml version="1.0" encoding="UTF-8"?>
+<core:ContentComponent  xmlns:core="clr-namespace:VertiGIS.Mobile.Workflow.Core;assembly=VertiGIS.Mobile.Workflow"
+                        xmlns="http://xamarin.com/schemas/2014/forms"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                        xmlns:views="clr-namespace:VertiGIS.Mobile.Toolkit.Views;assembly=VertiGIS.Mobile.Toolkit"
+                        x:Class="App1.Workflow.CustomFormComponent">
+    <StackLayout>
+        <Label>
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="This form element has a value of: "/>
+                    <Span Text="{Binding Element.Value}"/>
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+    </StackLayout>
+</core:ContentComponent>
+```
+
+```cs title="App1/App1/workflow/CustomFormComponent.xaml.cs"
 namespace App1.Workflow
 {
-    class CustomFormComponent : FormComponent
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class CustomFormComponent : ContentComponent
     {
-        private readonly View _view;
-
         public CustomFormComponent(Geocortex.Workflow.Runtime.Definition.Forms.Element element, string name)
-            : base (element, name)
+            : base(element, name)
         {
-            _view = new Label() {
-                Text = "This form element has a static value of 42"
-            };
-
-            // highlight-next-line
-            this.Element.Value = 42;
-
-            Add(new GenericComponent(_view));
+            BindingContext = this;
+            Element.Value = 42;
+            InitializeComponent();
         }
     }
 }
 ```
 
-You can then use the [Get Form Element Property](https://docs.vertigisstudio.com/workflow/latest/help/Default.htm#wf5/help/activities/get-form-element-property.htm) activity to access the `value` property, along with [other properties supported by custom form elements](https://docs.vertigisstudio.com/workflow/latest/help/Default.htm#wf5/help/form-elements/custom.htm#Custom_Form_Element_Properties%3FTocPath%3DForms%7CForm%2520Element%2520Reference%7CCustom%2520Form%2520Elements%7C_____1).
+You can then use the [Get Form Element Property](https://docs.geocortex.com/workflow/latest/help/Default.htm#wf5/help/activities/get-form-element-property.htm) activity to access the `Value` property, along with [other properties supported by custom form elements](https://docs.geocortex.com/workflow/latest/help/Default.htm#wf5/help/form-elements/custom.htm#Custom_Form_Element_Properties%3FTocPath%3DForms%7CForm%2520Element%2520Reference%7CCustom%2520Form%2520Elements%7C_____1).

--- a/docs/workflow/sdk-mobile-form-reference.mdx
+++ b/docs/workflow/sdk-mobile-form-reference.mdx
@@ -4,7 +4,7 @@ sidebar_label: Form Element Reference
 description: VertiGIS Studio Workflow - Reference for workflow form elements for web applications
 ---
 
-In the VertiGIS Studio Workflow .NET SDK, the only requirement is that custom form elements must implement `IFormComponent`. However, it is typically easier to extend the `ContentComponent` class, which is the recommend practice. The examples shown here extend `ContentComponent`.
+In the VertiGIS Studio Workflow .NET SDK, all custom form elements must implement `IFormComponent`. However, it is typically easier to extend the `ContentComponent` class, which is the recommend practice. The examples shown here extend `ContentComponent`.
 
 ```xml title="App1/App1/workflow/CustomFormElement.xaml"
 <?xml version="1.0" encoding="UTF-8"?>

--- a/docs/workflow/sdk-mobile-form-reference.mdx
+++ b/docs/workflow/sdk-mobile-form-reference.mdx
@@ -124,7 +124,7 @@ namespace App1.Workflow
 
 ## Access Properties of Custom Form Elements
 
-A custom form element may produce a value that a workflow needs to access at runtime. You can set a property on the `this.element` object to expose that value to the form.
+A custom form element may produce a value that a workflow needs to access at runtime. You can set a property on the `this.Element` object to expose that value to the form.
 
 ```xml title="App1/App1/workflow/CustomFormComponent.xaml"
 <?xml version="1.0" encoding="UTF-8"?>

--- a/docs/workflow/tutorial-mobile-activity-indicator-form-element.mdx
+++ b/docs/workflow/tutorial-mobile-activity-indicator-form-element.mdx
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 import MobilePrereqs from "./snippets/prereqs-mobile.mdx";
 import WorkflowUrlSnippet from "../snippets/workflow-url.mdx";
 
-Implementing a custom [form element](key-concepts.mdx#form-elements) allows you to augment the existing [form elements that come with VertiGIS Studio Workflow](https://docs.vertigisstudio.com/workflow/latest/help/Default.htm#wf5/help/form-elements/auto-complete.htm%3FTocPath%3DForms%7CForm%2520Element%2520Reference%7C_____0).
+Implementing a custom [form element](key-concepts.mdx#form-elements) allows you to augment the existing [form elements that come with VertiGIS Studio Workflow](https://docs.geocortex.com/workflow/latest/help/Default.htm#wf5/help/form-elements/auto-complete.htm%3FTocPath%3DForms%7CForm%2520Element%2520Reference%7C_____0).
 This article will walk you through creating a form element that displays a loading indicator.
 
 <img
@@ -32,31 +32,36 @@ Implementing a custom form element in VertiGIS Studio Mobile consists of three s
 
 ## Set up the Custom Form Element Skeleton
 
-1. Create a new file `LoadingIndicator.cs` in the platform agnostic project of the VertiGIS Studio Mobile [Quickstart](../mobile/sdk-overview.mdx).
-2. Add a new skeleton form element that implements `FormComponent`.
+1. Using Visual Studio, create a new file, using the Xamarin Forms: Content View template. Name the file `LoadingIndicator.xaml`, and place it in the platform agnostic project of the VertiGIS Studio Mobile [Quickstart](../mobile/sdk-overview.mdx).
+2. Change the base class to `ContentComponent` both in the xaml and in the code-behind.
 
-```cs title="App1/App1/workflow/LoadingIndicator.cs"
-using VertiGIS.Mobile.Workflow.Components;
-using Xamarin.Forms;
+```xml title="App1/App1/workflow/LoadingIndicator.xaml"
+<?xml version="1.0" encoding="UTF-8"?>
+// highlight-next-line
+<core:ContentComponent xmlns="http://xamarin.com/schemas/2014/forms"
+                       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                       xmlns:core="clr-namespace:VertiGIS.Mobile.Workflow.Core;assembly=VertiGIS.Mobile.Workflow"
+                       x:Class="App1.Workflow.LoadingIndicator">
+    <ContentView.Content>
+        <Label Text="Hello Xamarin.Forms!" />
+    </ContentView.Content>
+</core:ContentComponent>
+```
+
+```cs title="App1/App1/workflow/LoadingIndicator.xaml.cs"
+using VertiGIS.Mobile.Workflow.Core;
+using Xamarin.Forms.Xaml;
 
 namespace App1.Workflow
 {
-    public class LoadingIndicator : FormComponent
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    // highlight-next-line
+    public partial class LoadingIndicator : ContentComponent
     {
-        private readonly View _view;
-
         public LoadingIndicator(Geocortex.Workflow.Runtime.Definition.Forms.Element element, string name)
             : base(element, name)
         {
-            _view = new Label() { Text = "I'm a custom form component!" };
-
-            Add(new GenericComponent(_view));
-        }
-
-        public override void Render()
-        {
-            base.Render();
-            _view.IsEnabled = IsEnabled;
+            InitializeComponent();
         }
     }
 }
@@ -164,40 +169,26 @@ namespace App1.Workflow
 
 ## Add the Loading Indicator
 
-Next we can add the loading indicator to the form element.
+Next we can add the loading indicator to the form element xaml.
 
-```cs title="App1/App1/workflow/LoadingIndicator.cs"
-using VertiGIS.Mobile.Infrastructure.UI;
-using VertiGIS.Mobile.Workflow.Components;
-
-namespace App1.Workflow
-{
-    public class LoadingIndicator : FormComponent
-    {
-        private readonly EnhancedActivityIndicator _view;
-
-        public LoadingIndicator(Geocortex.Workflow.Runtime.Definition.Forms.Element element, string name)
-            : base(element, name)
-        {
-            // highlight-start
-            _view = new EnhancedActivityIndicator()
-            {
-                IsRunning = true,
-                HeightRequest = 75,
-                WidthRequest = 75,
-                Margin = 10
-            };
-            // highlight-end
-
-            Add(new GenericComponent(_view));
-        }
-    }
-}
+```xml title="App1/App1/workflow/LoadingIndicator.xaml.cs"
+<?xml version="1.0" encoding="UTF-8"?>
+<core:ContentComponent xmlns="http://xamarin.com/schemas/2014/forms"
+                       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                       xmlns:core="clr-namespace:VertiGIS.Mobile.Workflow.Core;assembly=VertiGIS.Mobile.Workflow"
+                       // highlight-next-line
+                       xmlns:views="clr-namespace:VertiGIS.Mobile.Toolkit.Views;assembly=VertiGIS.Mobile.Toolkit"
+                       x:Class="App1.Workflow.LoadingIndicator">
+    <ContentView.Content>
+        // highlight-next-line
+        <views:EnhancedActivityIndicator IsEnabled="{Binding IsEnabled}" IsRunning="True" HeightRequest="75" WidthRequest="75" Margin="10"/>
+    </ContentView.Content>
+</core:ContentComponent>
 ```
 
 ## Test your Activity
 
-Now you can [build a workflow for VertiGIS Studio Mobile](https://docs.vertigisstudio.com/mobileviewer/latest/admin-help/Default.htm#gmv/designer/add-a-workflow-to-an-app.htm) that uses your new custom form element! It is **essential** that this custom activity be run before the custom form element is used. It is best practice to run the form element registration activity at the start of a workflow.
+Now you can [build a workflow for VertiGIS Studio Mobile](https://docs.geocortex.com/mobileviewer/latest/admin-help/Default.htm#gmv/designer/add-a-workflow-to-an-app.htm) that uses your new custom form element! It is **essential** that this custom activity be run before the custom form element is used. It is best practice to run the form element registration activity at the start of a workflow.
 
 :::note
 
@@ -212,7 +203,7 @@ Now you can [build a workflow for VertiGIS Studio Mobile](https://docs.vertigiss
     </a>{" "}
     that registers and displays the custom form element and
     <a
-        href="https://docs.vertigisstudio.com/workflow/latest/help/Default.htm#wf5/help/import-export-workflows.htm"
+        href="https://docs.geocortex.com/workflow/latest/help/Default.htm#wf5/help/import-export-workflows.htm"
         target="_blank"
     >
         {" "}

--- a/docs/workflow/tutorial-mobile-activity-indicator-form-element.mdx
+++ b/docs/workflow/tutorial-mobile-activity-indicator-form-element.mdx
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 import MobilePrereqs from "./snippets/prereqs-mobile.mdx";
 import WorkflowUrlSnippet from "../snippets/workflow-url.mdx";
 
-Implementing a custom [form element](key-concepts.mdx#form-elements) allows you to augment the existing [form elements that come with VertiGIS Studio Workflow](https://docs.geocortex.com/workflow/latest/help/Default.htm#wf5/help/form-elements/auto-complete.htm%3FTocPath%3DForms%7CForm%2520Element%2520Reference%7C_____0).
+Implementing a custom [form element](key-concepts.mdx#form-elements) allows you to augment the existing [form elements that come with VertiGIS Studio Workflow](https://docs.vertigisstudio.com/workflow/latest/help/Default.htm#wf5/help/form-elements/auto-complete.htm%3FTocPath%3DForms%7CForm%2520Element%2520Reference%7C_____0).
 This article will walk you through creating a form element that displays a loading indicator.
 
 <img
@@ -188,7 +188,7 @@ Next we can add the loading indicator to the form element xaml.
 
 ## Test your Activity
 
-Now you can [build a workflow for VertiGIS Studio Mobile](https://docs.geocortex.com/mobileviewer/latest/admin-help/Default.htm#gmv/designer/add-a-workflow-to-an-app.htm) that uses your new custom form element! It is **essential** that this custom activity be run before the custom form element is used. It is best practice to run the form element registration activity at the start of a workflow.
+Now you can [build a workflow for VertiGIS Studio Mobile](https://docs.vertigisstudio.com/mobileviewer/latest/admin-help/Default.htm#gmv/designer/add-a-workflow-to-an-app.htm) that uses your new custom form element! It is **essential** that this custom activity be run before the custom form element is used. It is best practice to run the form element registration activity at the start of a workflow.
 
 :::note
 
@@ -203,7 +203,7 @@ Now you can [build a workflow for VertiGIS Studio Mobile](https://docs.geocortex
     </a>{" "}
     that registers and displays the custom form element and
     <a
-        href="https://docs.geocortex.com/workflow/latest/help/Default.htm#wf5/help/import-export-workflows.htm"
+        href="https://docs.vertigisstudio.com/workflow/latest/help/Default.htm#wf5/help/import-export-workflows.htm"
         target="_blank"
     >
         {" "}
@@ -274,10 +274,10 @@ You can do this by configuring the layout and app config to run a workflow. You 
 ```xml title="App1/App1/layout-large.xml"
 <?xml version="1.0" encoding="utf-8" ?>
 <layout
-    xmlns="https://geocortex.com/layout/v1"
-    xmlns:gxm="https://geocortex.com/layout/mobile/v1"
+    xmlns="https://vertigisstudio.com/layout/v1"
+    xmlns:gxm="https://vertigisstudio.com/layout/mobile/v1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://geocortex.com/layout/v1 ../../ViewerSpec/layout/layout-mobile.xsd">
+    xsi:schemaLocation="https://vertigisstudio.com/layout/v1 ../../ViewerSpec/layout/layout-mobile.xsd">
 	<gxm:taskbar id="taskbar" orientation="vertical">
 		<map slot="main">
 			<stack margin="0.8" slot="top-right" halign="end">

--- a/docs/workflow/tutorial-mobile-activity-indicator-form-element.mdx
+++ b/docs/workflow/tutorial-mobile-activity-indicator-form-element.mdx
@@ -274,10 +274,10 @@ You can do this by configuring the layout and app config to run a workflow. You 
 ```xml title="App1/App1/layout-large.xml"
 <?xml version="1.0" encoding="utf-8" ?>
 <layout
-    xmlns="https://vertigisstudio.com/layout/v1"
-    xmlns:gxm="https://vertigisstudio.com/layout/mobile/v1"
+    xmlns="https://geocortex.com/layout/v1"
+    xmlns:gxm="https://geocortex.com/layout/mobile/v1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://vertigisstudio.com/layout/v1 ../../ViewerSpec/layout/layout-mobile.xsd">
+    xsi:schemaLocation="https://geocortex.com/layout/v1 ../../ViewerSpec/layout/layout-mobile.xsd">
 	<gxm:taskbar id="taskbar" orientation="vertical">
 		<map slot="main">
 			<stack margin="0.8" slot="top-right" halign="end">


### PR DESCRIPTION
The two pages modified can be viewed here:
https://deploy-preview-13--vertigis-studio-dev-center.netlify.app/docs/workflow/sdk-mobile-form-reference
https://deploy-preview-13--vertigis-studio-dev-center.netlify.app/docs/workflow/tutorial-mobile-activity-indicator-form-element/