### PR TITLE
Update 2023-03-01-mobile-generic-event-listener.mdx

### DIFF
--- a/blog/2023-03-01-mobile-generic-event-listener.mdx
+++ b/blog/2023-03-01-mobile-generic-event-listener.mdx
@@ -259,7 +259,7 @@ The value provided to `commandArgumentInput` and the accessor used within the `G
 
 ## Raise Custom Events
 
-While Mobile exposes a number of events that may be listened to, there are times where it would be beneficial to respond to events that _aren't_ raised. Fortunately, there are also capabilities that allow app authors to raise custom events.
+While Mobile exposes a number of events that may be listened to, there are times where it would be beneficial to respond to events that _aren't_ raised out of the box. Fortunately, there are also capabilities that allow app authors to raise custom events.
 
 ### Raise Event through Action
 


### PR DESCRIPTION
I felt that "respond to events that _aren't_ raised" kind of sounds like it means somehow responding to the absence of an event. Add a few more words to make the idea more clear.