### PR TITLE
Use @latest suffix with npx command

### DIFF
--- a/docs/web/sdk-overview.mdx
+++ b/docs/web/sdk-overview.mdx
@@ -52,8 +52,8 @@ Components, services, and commands and operations interact to form a VertiGIS St
 
 ## Getting Started
 
-1. Run `npx @vertigis/web-sdk create <library-name>` where `<library-name>` is the name of the directory that will be created in the current working directory
-    - For example: `npx @vertigis/web-sdk create test-lib`
+1. Run `npx @vertigis/web-sdk@latest create <library-name>` where `<library-name>` is the name of the directory that will be created in the current working directory
+    - For example: `npx @vertigis/web-sdk@latest create test-lib`
 1. Open the `library-name` directory in your favorite IDE. We recommend using Visual Studio Code for the best experience.
 1. Run `npm start` to start the development server
 

--- a/docs/workflow/sdk-web-overview.mdx
+++ b/docs/workflow/sdk-web-overview.mdx
@@ -23,9 +23,9 @@ The VertiGIS Studio Workflow SDK provides a [development toolkit](https://github
 
 ## Getting Started
 
-1. Run `npx @vertigis/workflow-sdk create activity-pack` where `activity-pack` is the name of the directory that will be created in the current working directory
-    - For example: `npx @vertigis/workflow-sdk create test-activity-pack`
-1. Open the `activity-pack` directory in your favorite IDE. We recommend using Visual Studio Code for the best experience.
+1. Run `npx @vertigis/workflow-sdk@latest create <activity-pack-name>` where `<activity-pack-name>` is the name of the directory that will be created in the current working directory
+    - For example: `npx @vertigis/workflow-sdk@latest create test-activity-pack`
+1. Open the `activity-pack-name` directory in your favorite IDE. We recommend using Visual Studio Code for the best experience.
 1. Run `npm run generate` and follow the onscreen prompts to create a new activity or form element.
 1. Finally run `npm start` to start the development server.
 


### PR DESCRIPTION
If you run the `npx` command without a version suffix on the package name, you may get unexpected results as npm might use a previously-installed version rather than the latest. To make sure the outcome is what we expect, we are adding `@latest` to the package name.