### PR TITLE
Bug fixes and UI cleanup for Commands and Events reference

### DIFF
--- a/src/components/ViewerMessaging/MessagingArgument.tsx
+++ b/src/components/ViewerMessaging/MessagingArgument.tsx
@@ -153,11 +153,11 @@ export default function MessagingArgument(props: MessagingArgumentProps) {
                         {items.map((option, index) => (
                             // There's not a guaranteed safe identifier we can use for the key prop, fall back to index.
                             <div key={`${option.$ref}-${index}` || index}>
-                                <MessagingArgument
-                                    definition={option}
+                                <MessagingRef
+                                    isArray
+                                    name={option.$ref ?? ""}
                                     schema={schema}
                                 />
-                                []
                             </div>
                         ))}
                     </>

--- a/src/components/ViewerMessaging/MessagingArgument.tsx
+++ b/src/components/ViewerMessaging/MessagingArgument.tsx
@@ -121,7 +121,13 @@ export function listProperties(definition: Definition, schema: MessageSchema) {
                     return (
                         <div key={propName} className="margin-bottom--md">
                             <div className="margin-bottom--sm">
-                                <h4>{propName}</h4>
+                                <div
+                                    role="heading"
+                                    aria-level={4}
+                                    className="monospaceHeader"
+                                >
+                                    {propName}
+                                </div>
                                 {definition.required?.includes(propName) && (
                                     <span className="badge badge--secondary">
                                         Required

--- a/src/components/ViewerMessaging/MessagingDefinition.tsx
+++ b/src/components/ViewerMessaging/MessagingDefinition.tsx
@@ -16,6 +16,8 @@ export default function MessagingDefinition(props: MessagingDefinitionProps) {
     const { definitionName, schema } = props;
 
     const trimmedName = trimDefinitionsName(definitionName);
+    const parts = trimmedName.replace("/", ".").split(".");
+    const shortName = parts[parts.length - 1];
     const definition = getReferencedDefinition(definitionName, schema);
     if (!definition) {
         return null;
@@ -33,9 +35,12 @@ export default function MessagingDefinition(props: MessagingDefinitionProps) {
 
     return (
         <div className="margin-bottom--lg">
-            <h3 id={id}>{trimmedName}</h3>
+            <span>
+                <h2 id={id}>{shortName}</h2>
+                {shortName !== trimmedName && <h5>{`${trimmedName}`}</h5>}
+            </span>
             {getDescription(definition, schema, "margin-bottom--md")}
-            <div>Properties</div>
+            <h3>Properties</h3>
             {(!definition.properties ||
                 Object.keys(definition.properties).length === 0) && (
                 <em>This object doesn't currently contain any properties.</em>

--- a/src/components/ViewerMessaging/MessagingRef.tsx
+++ b/src/components/ViewerMessaging/MessagingRef.tsx
@@ -30,9 +30,7 @@ export default function MessagingRef(props: MessagingRefProps) {
                         {isArray && "[]"}
                     </a>
                 </code>
-                {shortName !== trimmedName && (
-                    <small>{` ${trimmedName}`}</small>
-                )}
+                {shortName !== trimmedName && <small>{`${trimmedName}`}</small>}
             </span>
         );
     }
@@ -54,7 +52,7 @@ export default function MessagingRef(props: MessagingRefProps) {
                         {isArray && "[]"}
                     </span>
                 </code>
-                <small>{` @arcgis.core.${parts.splice(1).join(".")}`}</small>
+                <small>{`@arcgis.core.${parts.splice(1).join(".")}`}</small>
             </span>
         );
     }
@@ -65,7 +63,7 @@ export default function MessagingRef(props: MessagingRefProps) {
                 {shortName}
                 {isArray && "[]"}
             </code>
-            {shortName !== trimmedName && <small>{` ${trimmedName}`}</small>}
+            {shortName !== trimmedName && <small>{`${trimmedName}`}</small>}
         </span>
     );
 }

--- a/src/components/ViewerMessaging/MessagingRef.tsx
+++ b/src/components/ViewerMessaging/MessagingRef.tsx
@@ -16,24 +16,56 @@ export default function MessagingRef(props: MessagingRefProps) {
     const { isArray, name, schema } = props;
 
     const trimmedName = trimDefinitionsName(name);
+    const parts = trimmedName.replace("/", ".").split(".");
+    const shortName = parts[parts.length - 1];
     const referencedDefinition = getReferencedDefinition(name, schema);
 
     // We'll only render definition tables for object types, everything else can be inlined.
     if (referencedDefinition && referencedDefinition.type === "object") {
         return (
-            <code>
-                <a href={`#${getArgumentDefinitionLinkId(name)}`}>
-                    {trimmedName}
-                    {isArray && "[]"}
-                </a>
-            </code>
+            <span>
+                <code>
+                    <a href={`#${getArgumentDefinitionLinkId(name)}`}>
+                        {shortName}
+                        {isArray && "[]"}
+                    </a>
+                </code>
+                {shortName !== trimmedName && (
+                    <small>{` ${trimmedName}`}</small>
+                )}
+            </span>
+        );
+    }
+
+    if (trimmedName.startsWith("esri") && !trimmedName.includes("rest-api")) {
+        const parts = trimmedName.replace(".", "/").split("/");
+        return (
+            <span>
+                <code>
+                    <span>
+                        <a
+                            href={`https://developers.arcgis.com/javascript/latest/api-reference/${parts.join(
+                                "-"
+                            )}.html`}
+                            target="_blank"
+                        >
+                            {parts[parts.length - 1]}
+                        </a>
+                        {isArray && "[]"}
+                    </span>
+                </code>
+                <small>{` @arcgis.core.${parts.splice(1).join(".")}`}</small>
+            </span>
         );
     }
 
     return (
-        <code>
-            {trimmedName}
-            {isArray && "[]"}
-        </code>
+        <span>
+            <code>
+                {shortName}
+                {isArray && "[]"}
+            </code>
+            {shortName !== trimmedName && <small>{` ${trimmedName}`}</small>}
+        </span>
     );
 }

--- a/src/components/ViewerMessaging/MessagingRef.tsx
+++ b/src/components/ViewerMessaging/MessagingRef.tsx
@@ -14,7 +14,6 @@ interface MessagingRefProps {
 
 export default function MessagingRef(props: MessagingRefProps) {
     const { isArray, name, schema } = props;
-
     const trimmedName = trimDefinitionsName(name);
     const parts = trimmedName.replace("/", ".").split(".");
     const shortName = parts[parts.length - 1];
@@ -30,7 +29,9 @@ export default function MessagingRef(props: MessagingRefProps) {
                         {isArray && "[]"}
                     </a>
                 </code>
-                {shortName !== trimmedName && <small>{`${trimmedName}`}</small>}
+                {shortName !== trimmedName && (
+                    <small>{` ${trimmedName}`}</small>
+                )}
             </span>
         );
     }
@@ -52,7 +53,7 @@ export default function MessagingRef(props: MessagingRefProps) {
                         {isArray && "[]"}
                     </span>
                 </code>
-                <small>{`@arcgis.core.${parts.splice(1).join(".")}`}</small>
+                <small>{` @arcgis.core.${parts.splice(1).join(".")}`}</small>
             </span>
         );
     }
@@ -63,7 +64,7 @@ export default function MessagingRef(props: MessagingRefProps) {
                 {shortName}
                 {isArray && "[]"}
             </code>
-            {shortName !== trimmedName && <small>{`${trimmedName}`}</small>}
+            {shortName !== trimmedName && <small>{` ${trimmedName}`}</small>}
         </span>
     );
 }

--- a/src/components/ViewerMessaging/MessagingTypeSummary.tsx
+++ b/src/components/ViewerMessaging/MessagingTypeSummary.tsx
@@ -55,14 +55,14 @@ export default function MessagingTypeSummary(props: MessagingTypeSummaryProps) {
 
                 return (
                     <div key={key} className="margin-bottom--lg">
-                        <h3 id={linkId}>{key}</h3>
+                        <h2 id={linkId}>{key}</h2>
                         {getDescription(item, schema, "margin-bottom--md")}
                         <div className="margin-bottom--md">
-                            <h4>{`Argument ${
+                            <h3>{`Argument ${
                                 typeIsOptional(inputItem) === true
                                     ? "(optional)"
                                     : ""
-                            }`}</h4>
+                            }`}</h3>
                             <div className="margin-left--sm">
                                 <MessagingArgument
                                     definition={inputItem}

--- a/src/components/ViewerMessaging/MessagingTypeSummary.tsx
+++ b/src/components/ViewerMessaging/MessagingTypeSummary.tsx
@@ -58,11 +58,11 @@ export default function MessagingTypeSummary(props: MessagingTypeSummaryProps) {
                         <h3 id={linkId}>{key}</h3>
                         {getDescription(item, schema, "margin-bottom--md")}
                         <div className="margin-bottom--md">
-                            <div>{`Argument ${
+                            <h4>{`Argument ${
                                 typeIsOptional(inputItem) === true
                                     ? "(optional)"
                                     : ""
-                            }`}</div>
+                            }`}</h4>
                             <div className="margin-left--sm">
                                 <MessagingArgument
                                     definition={inputItem}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -35,6 +35,10 @@
     font-weight: var(--ifm-font-weight-light);
 }
 
+.container [id] {
+    scroll-margin-top: var(--ifm-navbar-height);
+}
+
 .stackSplitImage {
     max-width: 30em;
     height: auto;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -48,6 +48,12 @@
     --ifm-heading-font-weight: bold;
 }
 
+.monospaceHeader {
+    font-family: monospace;
+    font-size: large;
+    font-weight: bold;
+}
+
 .footer .footer__links {
     margin-bottom: 3rem;
 }


### PR DESCRIPTION
- Used the proper semantic html headers to increase readability.
- De-emphasized full type names of external objects to increase readability.
- Linked to external ESRI JSAPI documentation where appropriate.
- Parsed and formatted descriptions (no more broken '{@link' text).
- Fixed jump links scrolling behind the header.