### PR TITLE
Fix Mobile urls

### DIFF
--- a/docs/mobile/configuration-app-config-getting-started.mdx
+++ b/docs/mobile/configuration-app-config-getting-started.mdx
@@ -272,7 +272,7 @@ The functionality of the `config` attribute is dependent on the fact that IDs ac
 
 The VertiGIS Studio Mobile SDK Samples project has a variety of app configuration samples:
 
--   [App Configuration Samples](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/AppConfiguration)
+-   [App Configuration Samples](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/AppConfiguration)
 
 ## Next Steps: Commands and Operations
 

--- a/docs/mobile/configuration-commands-operations.mdx
+++ b/docs/mobile/configuration-commands-operations.mdx
@@ -335,9 +335,9 @@ The second command/operation in this application is a `map.zoom-to-initial-viewp
 
 Check out the relevant VertiGIS Studio Mobile SDK Samples:
 
--   [Commands](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/AppConfiguration/Commands)
+-   [Commands](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/AppConfiguration/Commands)
 
--   [Map and Feature Commands](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/AppConfiguration/MapAndFeatureCommands)
+-   [Map and Feature Commands](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/AppConfiguration/MapAndFeatureCommands)
 
 ## Next Steps
 

--- a/docs/mobile/configuration-layout-getting-started.mdx
+++ b/docs/mobile/configuration-layout-getting-started.mdx
@@ -156,7 +156,7 @@ When adding custom components, you will need to [add their custom namespace](sdk
 
 The VertiGIS Studio Mobile SDK Samples project has a variety of layout configuration samples:
 
--   [Layout Configuration Samples](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Layout)
+-   [Layout Configuration Samples](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Layout)
 
 ## Next Steps: Components and App Config
 

--- a/docs/mobile/configuration-theme.mdx
+++ b/docs/mobile/configuration-theme.mdx
@@ -152,4 +152,4 @@ Color tabSecondaryForeground;
 
 ## Relevant SDK Sample
 
-The VertiGIS Studio Mobile SDK Samples has an example of [configuring the theme with the branding service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/AppConfiguration/Theme).
+The VertiGIS Studio Mobile SDK Samples has an example of [configuring the theme with the branding service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/AppConfiguration/Theme).

--- a/docs/mobile/sdk-commands-operations.mdx
+++ b/docs/mobile/sdk-commands-operations.mdx
@@ -195,4 +195,4 @@ class CustomService : ServiceBase
 
 ## Relevant SDK Sample
 
-The VertiGIS Studio Mobile SDK Samples project has a sample of [implementing a command with a custom service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/Service).
+The VertiGIS Studio Mobile SDK Samples project has a sample of [implementing a command with a custom service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/Service).

--- a/docs/mobile/sdk-component-service-interactions.mdx
+++ b/docs/mobile/sdk-component-service-interactions.mdx
@@ -54,6 +54,6 @@ class CustomComponent : ComponentBase
 
 Check out the relevant VertiGIS Studio Mobile SDK Samples:
 
--   [Basemap Toggle that uses Custom Services and Components](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/CustomSamples/BasemapToggle)
+-   [Basemap Toggle that uses Custom Services and Components](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/CustomSamples/BasemapToggle)
 
--   [Breadcrumb Tracker that uses Custom Services and Components](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/CustomSamples/BreadCrumbs)
+-   [Breadcrumb Tracker that uses Custom Services and Components](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/CustomSamples/BreadCrumbs)

--- a/docs/mobile/sdk-components-create.mdx
+++ b/docs/mobile/sdk-components-create.mdx
@@ -110,11 +110,11 @@ You've now accomplished the basics of extending VertiGIS Studio Mobile with a cu
 
 Check out the relevant VertiGIS Studio Mobile SDK Samples:
 
--   [Custom Component](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/Component)
+-   [Custom Component](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/Component)
 
--   [Component with Configuration](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/ComponentConfiguration)
+-   [Component with Configuration](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/ComponentConfiguration)
 
--   [Component with XAML UI](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/XamlComponent)
+-   [Component with XAML UI](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/XamlComponent)
 
 ## Next Steps
 

--- a/docs/mobile/sdk-components-internationalization.mdx
+++ b/docs/mobile/sdk-components-internationalization.mdx
@@ -13,6 +13,6 @@ Strings in custom components are internationalized using references to language 
 
 ## Relevant Samples
 
-The [SDK Samples](sdk-samples.mdx) project includes a [internationalization example](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Conceptual/Internationalization) which demonstrates how to configure resource files on a component level.
+The [SDK Samples](sdk-samples.mdx) project includes a [internationalization example](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Conceptual/Internationalization) which demonstrates how to configure resource files on a component level.
 
 You can also check out the use of [language strings in the quick start application](https://github.com/vertigis/vertigis-mobile-quickstart/blob/master/App1/App1/AppResources.resx).

--- a/docs/mobile/sdk-components-reference.mdx
+++ b/docs/mobile/sdk-components-reference.mdx
@@ -101,7 +101,7 @@ The preferred way to provide sub-dependencies to classes associated with compone
 
 ### XAML View
 
-XAML views and their respective "code-behind" are responsible for the presentation concerns of a component. Check out a [complete example in the SDK samples](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/XamlComponent).
+XAML views and their respective "code-behind" are responsible for the presentation concerns of a component. Check out a [complete example in the SDK samples](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/XamlComponent).
 
 XAML views can use any [XAML Controls](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/) along with built-in [VertiGIS Studio Mobile XAML Elements and styling](sdk-components-styling.mdx#using-vertigis-studio-mobile-views).
 
@@ -125,7 +125,7 @@ XAML views can use any [XAML Controls](https://learn.microsoft.com/en-us/dotnet/
 
 Component view models are responsible for populating properties with data for the view to bind to. The data for the view model is usually provided by the component class, which can consume app config or other data from the application through [dependency injection](sdk-dependency-injection.mdx). View models can use commands and operations to interact with application services and other components.
 
-Check out this example of a [component with a view model](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/CustomSamples/BreadCrumbs).
+Check out this example of a [component with a view model](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/CustomSamples/BreadCrumbs).
 
 ## Configuration Models
 
@@ -284,7 +284,7 @@ Components have an initialization method, which can be used to perform asynchron
 Always call `base.Dispose(disposing)` when overriding the `Dispose` method. `ComponentBase` already implements `IDisposable` and `IDisposableTracker`, so only override the `Dispose` method if you have created new managed resources which need to be cleaned up.
 :::
 
-To learn more about memory management in VertiGIS Studio Mobile, check out [this article](sdk-memory-leaks.mdx), and the [relevant SDK sample](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Conceptual/Disposal).
+To learn more about memory management in VertiGIS Studio Mobile, check out [this article](sdk-memory-leaks.mdx), and the [relevant SDK sample](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Conceptual/Disposal).
 
 ```cs
 [assembly: Component(typeof(CustomComponent), "component", XmlNamespace = XmlNamespaces.SamplesNamespace)]
@@ -368,11 +368,11 @@ class CustomComponent : ComponentBase
 
 Check out the relevant VertiGIS Studio Mobile SDK Samples:
 
--   [Custom Component](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/Component)
+-   [Custom Component](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/Component)
 
--   [Component with Configuration](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/ComponentConfiguration)
+-   [Component with Configuration](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/ComponentConfiguration)
 
--   [Component with XAML UI](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/XamlComponent)
+-   [Component with XAML UI](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/XamlComponent)
 
 ## Next Steps
 

--- a/docs/mobile/sdk-components-styling.mdx
+++ b/docs/mobile/sdk-components-styling.mdx
@@ -11,7 +11,7 @@ VertiGIS Studio Mobile Components are styled using [XAML styles](https://learn.m
 
 ## Using VertiGIS Studio Mobile Views
 
-VertiGIS Studio Mobile Views, like the `EnhancedButton` or `EnhancedSwitch`, can ease the development of custom components with the SDK. Check out the [relevant SDK sample](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/VSMElements) for an end to end example of their use.
+VertiGIS Studio Mobile Views, like the `EnhancedButton` or `EnhancedSwitch`, can ease the development of custom components with the SDK. Check out the [relevant SDK sample](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/VSMElements) for an end to end example of their use.
 
 <!-- Leaving DatePickerView commented out for now, since there is a bug in the language strings on the OK/cancel buttons on iOS and Android when used outside of Workflow.
 ### DatePickerView
@@ -119,8 +119,8 @@ class CustomComponent : ComponentBase
 
 Check out the relevant VertiGIS Studio Mobile SDK Samples:
 
--   [Styling buttons](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Layout/ButtonStyles)
+-   [Styling buttons](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Layout/ButtonStyles)
 
--   [Layout properties](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Layout/LayoutProperties)
+-   [Layout properties](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Layout/LayoutProperties)
 
--   [VertiGIS Studio Mobile Views](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/VSMElements)
+-   [VertiGIS Studio Mobile Views](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/VSMElements)

--- a/docs/mobile/sdk-components-viewmodel-helper-class.mdx
+++ b/docs/mobile/sdk-components-viewmodel-helper-class.mdx
@@ -46,4 +46,4 @@ namespace App1.Components
 
 ## Relevant SDK Sample
 
-The VertiGIS Studio Mobile SDK Samples has an example of a [breadcrumbs component that uses a viewmodel](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/CustomSamples/BreadCrumbs).
+The VertiGIS Studio Mobile SDK Samples has an example of a [breadcrumbs component that uses a viewmodel](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/CustomSamples/BreadCrumbs).

--- a/docs/mobile/sdk-dependency-injection.mdx
+++ b/docs/mobile/sdk-dependency-injection.mdx
@@ -204,4 +204,4 @@ namespace VertiGIS.Mobile.Samples.Samples.Custom.Component
 
 ## Relevant SDK Sample
 
-Check out the VertiGIS Studio Mobile SDK Sample for [dependency injection](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Conceptual/DependencyInjection).
+Check out the VertiGIS Studio Mobile SDK Sample for [dependency injection](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Conceptual/DependencyInjection).

--- a/docs/mobile/sdk-edit-layout-app-config.mdx
+++ b/docs/mobile/sdk-edit-layout-app-config.mdx
@@ -156,11 +156,11 @@ You've now accomplished the basics of building a VertiGIS Studio Mobile Applicat
 
 Check out the relevant VertiGIS Studio Mobile SDK Samples:
 
--   [Various Layout Samples](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Layout)
+-   [Various Layout Samples](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Layout)
 
--   [Various Configuration Samples](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/AppConfiguration)
+-   [Various Configuration Samples](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/AppConfiguration)
 
--   [A complete VertiGIS Studio Mobile App](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/App/VSMViewer)
+-   [A complete VertiGIS Studio Mobile App](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/App/VSMViewer)
 
 ## Next Steps
 

--- a/docs/mobile/sdk-internationalization.mdx
+++ b/docs/mobile/sdk-internationalization.mdx
@@ -24,7 +24,7 @@ The [Quickstart](https://github.com/vertigis/vertigis-mobile-quickstart) project
 
 Check out the relevant VertiGIS Studio Mobile SDK Sample:
 
--   [Internationalization](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Conceptual/Internationalization)
+-   [Internationalization](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Conceptual/Internationalization)
 
 ## Next Steps
 

--- a/docs/mobile/sdk-memory-leaks.mdx
+++ b/docs/mobile/sdk-memory-leaks.mdx
@@ -45,4 +45,4 @@ Using `DisposeTrackers()` is a shortcut which is functionally identical to calli
 
 ## Relevant SDK Sample
 
-Check out the sample on the [disposal pattern in VertiGIS Studio Mobile](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Conceptual/Disposal).
+Check out the sample on the [disposal pattern in VertiGIS Studio Mobile](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Conceptual/Disposal).

--- a/docs/mobile/sdk-services-create.mdx
+++ b/docs/mobile/sdk-services-create.mdx
@@ -144,11 +144,11 @@ namespace App1.Services
 
 Check out the relevant VertiGIS Studio Mobile SDK Samples:
 
--   [Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/Service)
+-   [Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/Service)
 
--   [Basemap Toggle that uses a Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/CustomSamples/BasemapToggle)
+-   [Basemap Toggle that uses a Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/CustomSamples/BasemapToggle)
 
--   [Breadcrumb Tracker that Uses a Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/CustomSamples/BreadCrumbs)
+-   [Breadcrumb Tracker that Uses a Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/CustomSamples/BreadCrumbs)
 
 ## Next Steps
 

--- a/docs/mobile/sdk-services-reference.mdx
+++ b/docs/mobile/sdk-services-reference.mdx
@@ -45,7 +45,7 @@ Services have an initialization method, which can be used to perform asynchronou
 Always call `base.Dispose(disposing)` when overriding the `Dispose` method. `ServiceBase` already implements `IDisposable` and `IDisposableTracker`, so only override the `Dispose` method if you have created new managed resources which need to be cleaned up.
 :::
 
-To learn more about memory management in VertiGIS Studio Mobile, check out [this article](sdk-memory-leaks.mdx), and the [relevant SDK sample](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Conceptual/Disposal).
+To learn more about memory management in VertiGIS Studio Mobile, check out [this article](sdk-memory-leaks.mdx), and the [relevant SDK sample](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Conceptual/Disposal).
 
 ```cs
 [assembly: Service(typeof(CustomService), PropertiesAutowired = true)]
@@ -233,11 +233,11 @@ namespace App1.Services
 
 Check out the relevant VertiGIS Studio Mobile SDK Samples:
 
--   [Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/Service)
+-   [Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/Service)
 
--   [Basemap Toggle that uses a Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/CustomSamples/BasemapToggle)
+-   [Basemap Toggle that uses a Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/CustomSamples/BasemapToggle)
 
--   [Breadcrumb Tracker that Uses a Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/CustomSamples/BreadCrumbs)
+-   [Breadcrumb Tracker that Uses a Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/CustomSamples/BreadCrumbs)
 
 ## Next Steps
 

--- a/docs/mobile/snippets/relevant-workflow-samples.mdx
+++ b/docs/mobile/snippets/relevant-workflow-samples.mdx
@@ -1,7 +1,7 @@
 The VertiGIS Studio Mobile SDK Samples project has a variety of workflow samples:
 
--   [Run a Workflow](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Workflow/RunWorkflow)
+-   [Run a Workflow](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Workflow/RunWorkflow)
 
--   [Build a Custom Activity](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Workflow/CustomActivity)
+-   [Build a Custom Activity](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Workflow/CustomActivity)
 
--   [Build a Custom Form Element](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Workflow/CustomFormComponent)
+-   [Build a Custom Form Element](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Workflow/CustomFormComponent)

--- a/docs/mobile/tutorial-change-default-behavior.mdx
+++ b/docs/mobile/tutorial-change-default-behavior.mdx
@@ -235,9 +235,9 @@ Congratulations! You just changed the default behavior for a built in component 
 
 Check out the relevant VertiGIS Studio Mobile SDK Samples:
 
--   [Configuring basic commands](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/AppConfiguration/Commands)
+-   [Configuring basic commands](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/AppConfiguration/Commands)
 
--   [Configuring map and feature commands](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/AppConfiguration/MapAndFeatureCommands)
+-   [Configuring map and feature commands](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/AppConfiguration/MapAndFeatureCommands)
 
 ## Next Steps
 

--- a/docs/mobile/tutorial-change-default-map-click-behavior.mdx
+++ b/docs/mobile/tutorial-change-default-map-click-behavior.mdx
@@ -323,7 +323,7 @@ This pattern of configuring behavior with a workflow can be applied to numerous 
     <UseCaseCard
         title="SDK Sample that Demonstrates Overriding Default Behaviors"
         description="Check out the SDK Sample for overriding default behaviors"
-        link="https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/AppConfiguration/MapAndFeatureCommands"
+        link="https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/AppConfiguration/MapAndFeatureCommands"
     />
     <UseCaseCard
         title="Implement Custom Command or Operation"

--- a/docs/mobile/tutorial-customize-application-theme.mdx
+++ b/docs/mobile/tutorial-customize-application-theme.mdx
@@ -286,4 +286,4 @@ You can customize the theme by changing any of the [built-in color keys](configu
 
 ## Relevant SDK Samples
 
-The VertiGIS Studio Mobile SDK Samples has an example of [changing the theme through configuration](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/AppConfiguration/Theme).
+The VertiGIS Studio Mobile SDK Samples has an example of [changing the theme through configuration](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/AppConfiguration/Theme).

--- a/docs/mobile/tutorial-implement-command-operation.mdx
+++ b/docs/mobile/tutorial-implement-command-operation.mdx
@@ -158,9 +158,9 @@ Congratulations! You just created your first custom operation. You can easily te
 
 Check out the relevant VertiGIS Studio Mobile SDK Samples:
 
--   [Custom Operation](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/Operation)
+-   [Custom Operation](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/Operation)
 
--   [Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/Service)
+-   [Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/Service)
 
 ## Next Steps
 

--- a/docs/mobile/tutorial-implement-component-participate-app-config.mdx
+++ b/docs/mobile/tutorial-implement-component-participate-app-config.mdx
@@ -380,7 +380,7 @@ App Config is defined in the [app JSON](sdk-edit-layout-app-config.mdx) and link
 
 Check out the relevant VertiGIS Studio Mobile SDK Sample:
 
--   [Component with Configuration](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/ComponentConfiguration)
+-   [Component with Configuration](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/ComponentConfiguration)
 
 ## Next Steps
 

--- a/docs/mobile/tutorial-implement-component-with-ui.mdx
+++ b/docs/mobile/tutorial-implement-component-with-ui.mdx
@@ -201,7 +201,7 @@ Learn about how to extend this component to [participate in app config](tutorial
 From here, you can implement your own business logic and interfaces, create custom [Commands and Operations](sdk-commands-operations.mdx#implementing-commands-and-operations) that are powered by and/or interact with your component, and much more. The [MAUI documentation](https://learn.microsoft.com/en-us/dotnet/maui/xaml/) has excellent guides to implementing user interfaces in Xaml.
 
 :::info
-VertiGIS Studio Mobile comes with built-in [Enhanced Components](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/VSMElements) that can ease development and styling of custom UI.
+VertiGIS Studio Mobile comes with built-in [Enhanced Components](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/VSMElements) that can ease development and styling of custom UI.
 :::
 
 ### Example: Progress Bar
@@ -376,9 +376,9 @@ Learn more of this ViewModel's use of the VertiGIS Studio Mobile helper class [`
 
 Check out the relevant VertiGIS Studio Mobile SDK Samples:
 
--   [Custom Component](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/Component)
+-   [Custom Component](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/Component)
 
--   [Custom Component with XAML](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/XamlComponent)
+-   [Custom Component with XAML](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/XamlComponent)
 
 ## Next Steps
 

--- a/docs/mobile/tutorial-implement-service-fetch-dynamic-data.mdx
+++ b/docs/mobile/tutorial-implement-service-fetch-dynamic-data.mdx
@@ -237,9 +237,9 @@ You've now built a custom service that fetches from a dynamic data source and ex
 
 Check out the relevant VertiGIS Studio Mobile SDK Samples:
 
--   [Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Custom/Service)
+-   [Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Custom/Service)
 
--   [Basemap Toggle that uses a Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/CustomSamples/BasemapToggle)
+-   [Basemap Toggle that uses a Custom Service](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/CustomSamples/BasemapToggle)
 
 ## Next Steps
 

--- a/docs/workflow/sdk-mobile-overview.mdx
+++ b/docs/workflow/sdk-mobile-overview.mdx
@@ -19,7 +19,7 @@ Creating custom workflow activities for VertiGIS Studio Mobile requires the deve
 
 <SdkLimitationsWarning />
 
-The VertiGIS Studio Mobile SDK includes various [SDK Samples](../mobile/sdk-samples.mdx) for development, including [a sample which demonstrate custom workflow functionality](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Workflow/CustomActivity) .
+The VertiGIS Studio Mobile SDK includes various [SDK Samples](../mobile/sdk-samples.mdx) for development, including [a sample which demonstrate custom workflow functionality](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Workflow/CustomActivity) .
 
 ## Next Steps
 

--- a/docs/workflow/tutorial-mobile-activity-indicator-form-element.mdx
+++ b/docs/workflow/tutorial-mobile-activity-indicator-form-element.mdx
@@ -295,4 +295,4 @@ You can do this by configuring the layout and app config to run a workflow. You 
 
 Check out the relevant VertiGIS Studio Mobile SDK Sample:
 
--   [Custom Workflow Form Element](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Workflow/CustomFormComponent)
+-   [Custom Workflow Form Element](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Workflow/CustomFormComponent)

--- a/docs/workflow/tutorial-mobile-calculate-logarithm-activity.mdx
+++ b/docs/workflow/tutorial-mobile-calculate-logarithm-activity.mdx
@@ -319,7 +319,7 @@ You can do this by configuring the layout and app config to run a workflow. You 
 
 Check out the relevant VertiGIS Studio Mobile SDK Sample:
 
--   [Custom Workflow Activity](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/VSM.Samples/Samples/Workflow/CustomActivity)
+-   [Custom Workflow Activity](https://github.com/vertigis/vertigis-mobile-samples/tree/master/VSM.Samples/Samples/Workflow/CustomActivity)
 
 ## Next Steps
 


### PR DESCRIPTION
URLs pointing to the Mobile Samples repo on GitHub had a duplicated /VSM.Samples/ section in the path, which was cleaned up in https://github.com/vertigis/vertigis-mobile-samples/pull/13. Update all the affected URLs.